### PR TITLE
feat: update liquibase version for newest command console

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 rootProject.name=liquibase-groovy-dsl
 
 # What version of the DSL are we building?
-liquibaseGroovyDslVersion=3.0.3
+liquibaseGroovyDslVersion=3.1.0-SNAPSHOT
 
 # When we download a maven dependency, should we also get source files?
 downloadSources=false
@@ -18,7 +18,7 @@ groovyVersion=3.0.15
 #liquibaseVersion=4.0.0-local-SNAPSHOT
 #liquibaseVersion=4.2.2
 #liquibaseVersion=4.3.3
-liquibaseVersion=4.16.1
+liquibaseVersion=4.27.0
 
 junitVersion=4.12
 h2Version=1.4.185

--- a/src/main/groovy/org/liquibase/groovy/liquibase.groovy
+++ b/src/main/groovy/org/liquibase/groovy/liquibase.groovy
@@ -16,13 +16,13 @@ package org.liquibase.groovy
 
 import liquibase.parser.ext.GroovyLiquibaseChangeLogParser
 import liquibase.parser.*
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 
 
 ChangeLogParserFactory.getInstance().register(new GroovyLiquibaseChangeLogParser())
 
 //changeLogFile = 'src/test/changelog/basic-changelog.groovy'
-//resourceAccessor = new FileSystemResourceAccessor(new File('.'))
+//resourceAccessor = new DirectoryResourceAccessor(new File('.'))
 //parser = ChangeLogParserFactory.getInstance().getParser(changeLogFile, resourceAccessor)
 //
 //def changeLog = parser.parse(changeLogFile, null, resourceAccessor)

--- a/src/test/groovy/org/liquibase/groovy/GroovySerializerTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/GroovySerializerTests.groovy
@@ -13,7 +13,7 @@
  */
 package org.liquibase.groovy
 
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 import liquibase.serializer.ChangeLogSerializerFactory
 import liquibase.serializer.ext.GroovyChangeLogSerializer
 
@@ -34,7 +34,7 @@ class GroovySerializerTests {
 
     @Before
     void registerSerializer() {
-        resourceAccessor = new FileSystemResourceAccessor(new File('.'))
+        resourceAccessor = new DirectoryResourceAccessor(new File('.'))
         serializerFactory = ChangeLogSerializerFactory.instance
         ChangeLogSerializerFactory.getInstance().register(new GroovyChangeLogSerializer())
     }

--- a/src/test/groovy/org/liquibase/groovy/delegate/ChangeSetMethodTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/ChangeSetMethodTests.groovy
@@ -22,9 +22,7 @@ import liquibase.change.core.RawSQLChange
 import liquibase.change.core.UpdateDataChange
 import liquibase.exception.ChangeLogParseException
 import liquibase.exception.RollbackImpossibleException
-import liquibase.resource.FileSystemResourceAccessor
 import org.junit.Test
-import org.junit.Ignore
 import static org.junit.Assert.*
 
 /**

--- a/src/test/groovy/org/liquibase/groovy/delegate/ChangeSetTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/ChangeSetTests.groovy
@@ -13,7 +13,7 @@
  */
 package org.liquibase.groovy.delegate
 
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 import org.junit.After
 import org.junit.Before
 import liquibase.changelog.ChangeLogParameters
@@ -22,7 +22,6 @@ import liquibase.changelog.DatabaseChangeLog
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 
-import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
 
 
@@ -38,7 +37,7 @@ class ChangeSetTests {
     def CHANGESET_FILEPATH = '/filePath'
     def sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
     def changeSet
-    def resourceAccessor = new FileSystemResourceAccessor()
+    def resourceAccessor = new DirectoryResourceAccessor(new File(''))
     def oldStdOut = System.out;
     def bufStr = new ByteArrayOutputStream()
 

--- a/src/test/groovy/org/liquibase/groovy/delegate/CustomRefactoringTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/CustomRefactoringTests.groovy
@@ -21,7 +21,7 @@ import liquibase.change.core.RawSQLChange
 import liquibase.change.core.SQLFileChange
 import liquibase.change.core.ExecuteShellCommandChange
 import liquibase.change.custom.CustomChangeWrapper
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 
 /**
  * This is one of several classes that test the creation of refactoring changes for ChangeSets. This

--- a/src/test/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegateIncludeAllTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegateIncludeAllTests.groovy
@@ -23,7 +23,7 @@ import liquibase.precondition.core.DBMSPrecondition
 import liquibase.precondition.core.PreconditionContainer
 import liquibase.precondition.core.RunningAsPrecondition
 import liquibase.resource.ClassLoaderResourceAccessor
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 import org.junit.Before
 import org.junit.Test
 
@@ -56,12 +56,12 @@ class DatabaseChangeLogDelegateIncludeAllTests {
 
     @Before
     void registerParser() {
-        // when Liquibase runs, it gives a FileSystemResourceAccessor based on the absolute path of
+        // when Liquibase runs, it gives a DirectoryResourceAccessor based on the absolute path of
         // the current working directory.  We'll do the same for this test.  We'll make a file for
         // ".", then get that file's absolute path, which produces something like
         // "/some/path/to/dir/.", just like what Liquibase does.
         def f = new File(".")
-        resourceAccessor = new FileSystemResourceAccessor(new File(f.absolutePath))
+        resourceAccessor = new DirectoryResourceAccessor(new File(f.absolutePath))
         parserFactory = ChangeLogParserFactory.instance
         ChangeLogParserFactory.getInstance().register(new GroovyLiquibaseChangeLogParser())
         // make sure we start with clean temporary directories before each test

--- a/src/test/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegateTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegateTests.groovy
@@ -23,7 +23,7 @@ import liquibase.parser.ext.GroovyLiquibaseChangeLogParser
 import liquibase.precondition.Precondition
 import liquibase.precondition.core.DBMSPrecondition
 import liquibase.precondition.core.PreconditionContainer
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -58,12 +58,12 @@ class DatabaseChangeLogDelegateTests {
 
     @Before
     void registerParser() {
-        // when Liquibase runs, it gives a FileSystemResourceAccessor based on the absolute path of
+        // when Liquibase runs, it gives a DirectoryResourceAccessor based on the absolute path of
         // the current working directory.  We'll do the same for this test.  We'll make a file for
         // ".", then get that file's absolute path, which produces something like
         // "/some/path/to/dir/.", just like what Liquibase does.
         def f = new File(".")
-        resourceAccessor = new FileSystemResourceAccessor(new File(f.absolutePath))
+        resourceAccessor = new DirectoryResourceAccessor(new File(f.absolutePath))
         parserFactory = ChangeLogParserFactory.instance
         ChangeLogParserFactory.getInstance().register(new GroovyLiquibaseChangeLogParser())
         // make sure we start with clean temporary directories before each test

--- a/src/test/groovy/org/liquibase/groovy/delegate/GroovyChangeDelegateTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/GroovyChangeDelegateTests.groovy
@@ -16,7 +16,7 @@ package org.liquibase.groovy.delegate
 import org.junit.Test
 import org.junit.Ignore
 import static org.junit.Assert.*
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 
 /**
  * <p></p>
@@ -33,7 +33,7 @@ class GroovyChangeDelegateTests extends ChangeSetTests {
         def validateWasCalled = false
         def changeWasCalled = false
         def rollbackWasCalled = false
-        resourceAccessor = new FileSystemResourceAccessor()
+        resourceAccessor = new DirectoryResourceAccessor()
 
         buildChangeSet {
             groovyChange {

--- a/src/test/groovy/org/liquibase/groovy/delegate/NonRefactoringTransformationTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/NonRefactoringTransformationTests.groovy
@@ -26,7 +26,7 @@ import liquibase.change.core.StopChange
 import liquibase.change.core.TagDatabaseChange
 import liquibase.change.core.UpdateDataChange
 import liquibase.exception.ChangeLogParseException
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 import org.junit.Test
 
 import static org.junit.Assert.assertEquals

--- a/src/test/groovy/org/liquibase/groovy/serialize/SerializerTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/serialize/SerializerTests.groovy
@@ -14,7 +14,7 @@
 
 package org.liquibase.groovy.serialize
 
-import liquibase.resource.FileSystemResourceAccessor
+import liquibase.resource.DirectoryResourceAccessor
 import liquibase.serializer.ChangeLogSerializerFactory
 
 import org.junit.Before
@@ -36,7 +36,7 @@ class SerializerTests {
 
     @Before
     void registerSerializer() {
-        resourceAccessor = new FileSystemResourceAccessor(new File('.'))
+        resourceAccessor = new DirectoryResourceAccessor(new File('.'))
         serializerFactory = ChangeLogSerializerFactory.instance
         ChangeLogSerializerFactory.getInstance().register(new GroovyChangeLogSerializer())
         serializer = serializerFactory.getSerializer('groovy')


### PR DESCRIPTION
Compatibility with newest database version (e.g.: Cassandra CQL)
Remove deprecated liquibase.resource.FileSystemResourceAccessor class